### PR TITLE
update bintray url to artifacotry as bintray has been retired

### DIFF
--- a/groovy/tools/chocolateyInstall.ps1
+++ b/groovy/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageName = 'groovy'
 $packageVersion = $env:chocolateyPackageVersion
 $checksum = 'F7FFAED8AA63611BF68BEF0DB512AB979926C6E8778393FE573C553B9BD39E10'
-$url = 'https://dl.bintray.com/groovy/maven/apache-groovy-binary-3.0.5.zip'
+$url = 'https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.5.zip'
 $toolsDir = Get-ToolsLocation
 $groovy_home = Join-Path $toolsDir "$packageName-$packageVersion"
 $groovy_bat = Join-Path $groovy_home 'bin/groovy.bat'


### PR DESCRIPTION
I'd noticed that old versions of the groovy chocolatey package are not working, now that bintray is retired (see announcement [here](http://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter)).

So I've changed the url to point to artifactory instead (https://groovy.jfrog.io/artifactory).

This change would need to be done on all tags, but not sure how you want to drive that process, hence I'm just merging into master here.